### PR TITLE
Update image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM resin/rpi-raspbian:stretch
+FROM balenalib/rpi-raspbian
 LABEL maintainer="Marcos V. Rubido <docker@marcosvrs.com>"
 
 ENV ARCH=arm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM balenalib/rpi-raspbian
+FROM balenalib/rpi-raspbian:stretch
 LABEL maintainer="Marcos V. Rubido <docker@marcosvrs.com>"
 
 ENV ARCH=arm


### PR DESCRIPTION
Resin has been deprecated and has now moved all docker images under balenalib 
Read more here:
https://hub.docker.com/r/resin/rpi-raspbian
New image:
https://hub.docker.com/r/balenalib/rpi-raspbian